### PR TITLE
feat: component macro and enhance Activity with children

### DIFF
--- a/demo/src/bin/functional_component.rs
+++ b/demo/src/bin/functional_component.rs
@@ -1,0 +1,39 @@
+use gpui::prelude::*;
+use gpui::*;
+use gpui_rsx::{component, rsx};
+
+use gpui_rsx_demo::button::FunctionalButton;
+
+struct AppView {
+    focus_handle: FocusHandle,
+}
+
+impl Render for AppView {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let focus_handle = self.focus_handle.clone();
+        rsx! {
+            <div>
+                <FunctionalButton label={"Inactive Button".to_string()} is_active={false} />
+                <div ref={&self.focus_handle}>
+                    {"Focus Target"}
+                </div>
+                <div on_click={move |_event, window, cx| focus_handle.focus(window, cx)}>
+                    {"Click to Focus"}
+                </div>
+            </div>
+        }
+    }
+}
+
+use gpui_platform::application;
+
+fn main() {
+    application().run(|cx: &mut App| {
+        let _ = cx.open_window(WindowOptions::default(), |_, cx| {
+            cx.new(|cx| AppView {
+                focus_handle: cx.focus_handle(),
+            })
+        });
+        cx.activate(true);
+    });
+}

--- a/demo/src/bin/test_component.rs
+++ b/demo/src/bin/test_component.rs
@@ -1,0 +1,8 @@
+use gpui_rsx::rsx_expand;
+
+fn main() {
+    let s = rsx_expand! {
+        <div ref={my_ref} />
+    };
+    println!("{}", s);
+}

--- a/demo/src/button.rs
+++ b/demo/src/button.rs
@@ -1,0 +1,14 @@
+use gpui::prelude::*;
+use gpui::*;
+use gpui_rsx::{component, rsx};
+
+#[component]
+pub fn FunctionalButton(label: String, is_active: bool) -> impl IntoElement {
+    let bg_color = if is_active { gpui::rgb(0x2563eb) } else { gpui::rgb(0x475569) };
+    
+    rsx! {
+        <div class="px-4 py-2" bg={bg_color}>
+            {label}
+        </div>
+    }
+}

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod button;

--- a/src/codegen/attribute.rs
+++ b/src/codegen/attribute.rs
@@ -130,6 +130,11 @@ pub(crate) fn generate_attr_methods_with_mode(
                 return;
             }
 
+            if name_str == "ref" {
+                out.push(quote! { .track_focus(#value) });
+                return;
+            }
+
             // 默认：直接作为方法调用
             out.push(quote! { .#name(#value) });
         }

--- a/src/codegen/element.rs
+++ b/src/codegen/element.rs
@@ -238,6 +238,17 @@ fn generate_element_checked(
             RsxAttribute::Value { name, value } if tag_str == "canvas" && name == "paint" => {
                 canvas_paint = Some(value);
             }
+            RsxAttribute::Value { name, value } if tag_str == "Activity" && name == "mode" => {
+                methods.push(quote! {
+                    .map(|__el| {
+                        if #value == "visible" {
+                            __el.visible()
+                        } else {
+                            __el.invisible()
+                        }
+                    })
+                });
+            }
             RsxAttribute::Value { name, value } if tag_str == "svg" && name == "src" => {
                 methods.push(quote! { .path(#value) });
             }
@@ -389,7 +400,7 @@ fn generate_tag(
         // HTML 标签：统一映射为 div()
         "div" | "span" | "section" | "article" | "header" | "footer" | "main" | "nav" | "aside"
         | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "label" | "a" | "button" | "input"
-        | "textarea" | "select" | "form" | "ul" | "ol" | "li" => {
+        | "textarea" | "select" | "form" | "ul" | "ol" | "li" | "Activity" => {
             quote! { div() }
         }
         _ => quote! { #path() },

--- a/src/codegen/element.rs
+++ b/src/codegen/element.rs
@@ -207,6 +207,7 @@ fn generate_element_checked(
     let mut canvas_prepaint = None;
     let mut canvas_paint = None;
     let mut has_styled = false;
+    let is_component = tag_str.chars().next().map_or(false, |c| c.is_ascii_uppercase());
     let mut needs_id = false;
 
     // 预分配方法链容量：
@@ -245,7 +246,7 @@ fn generate_element_checked(
             }
             _ => {
                 let analysis = analyze_attr(attr);
-                if !needs_id && analysis.needs_id {
+                if !needs_id && analysis.needs_id && !is_component {
                     needs_id = true;
                 }
                 generate_attr_methods_with_mode(attr, analysis.hints(), &mut methods, mode);

--- a/src/component.rs
+++ b/src/component.rs
@@ -1,0 +1,79 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Error, FnArg, Ident, ItemFn, Pat, PatType, Type};
+
+fn parse_prop<'a>(arg: &'a FnArg) -> syn::Result<(&'a Ident, &'a Type)> {
+    match arg {
+        FnArg::Typed(PatType { pat, ty, .. }) => match &**pat {
+            Pat::Ident(pat_ident) => Ok((&pat_ident.ident, &**ty)),
+            _ => Err(Error::new_spanned(
+                pat,
+                "Unsupported pattern in component argument",
+            )),
+        },
+        FnArg::Receiver(_) => Err(Error::new_spanned(
+            arg,
+            "Methods (self) are not supported in functional components",
+        )),
+    }
+}
+
+pub fn generate_component(item: ItemFn) -> syn::Result<TokenStream> {
+    let vis = &item.vis;
+    let name = &item.sig.ident;
+    let body = &item.block;
+
+    let mut struct_fields = TokenStream::new();
+    let mut builder_methods = TokenStream::new();
+    let mut init_fields = TokenStream::new();
+    let mut field_extracts = TokenStream::new();
+
+    for arg in &item.sig.inputs {
+        let (ident, ty) = parse_prop(arg)?;
+
+        let err_msg = format!("Missing required property `{ident}` for component `{name}`");
+        struct_fields.extend(quote! { #ident: ::std::option::Option<#ty>, });
+
+        builder_methods.extend(quote! {
+            #vis fn #ident(mut self, #ident: #ty) -> Self {
+                self.#ident = ::std::option::Option::Some(#ident);
+                self
+            }
+        });
+
+        init_fields.extend(quote! { #ident: ::std::option::Option::None, });
+
+        field_extracts.extend(quote! { let #ident = self.#ident.expect(#err_msg); });
+    }
+
+    Ok(quote! {
+        #vis struct #name {
+            #struct_fields
+        }
+
+        #[allow(non_snake_case)]
+        #vis fn #name() -> #name {
+            #name {
+                #init_fields
+            }
+        }
+
+        impl #name {
+            #builder_methods
+        }
+
+        impl ::gpui::IntoElement for #name {
+            type Element = ::gpui::AnyElement;
+
+            fn into_element(self) -> Self::Element {
+                #field_extracts
+
+                let __rendered = (move || {
+                    #body
+                })();
+
+                ::gpui::IntoElement::into_any_element(__rendered)
+            }
+        }
+    })
+}

--- a/src/component.rs
+++ b/src/component.rs
@@ -27,9 +27,17 @@ pub fn generate_component(item: ItemFn) -> syn::Result<TokenStream> {
     let mut builder_methods = TokenStream::new();
     let mut init_fields = TokenStream::new();
     let mut field_extracts = TokenStream::new();
+    
+    struct_fields.extend(quote! { children: ::std::vec::Vec<::gpui::AnyElement>, });
+    init_fields.extend(quote! { children: ::std::vec::Vec::new(), });
 
     for arg in &item.sig.inputs {
         let (ident, ty) = parse_prop(arg)?;
+
+        if ident == "children" {
+            field_extracts.extend(quote! { let children = self.children; });
+            continue;
+        }
 
         let err_msg = format!("Missing required property `{ident}` for component `{name}`");
         struct_fields.extend(quote! { #ident: ::std::option::Option<#ty>, });
@@ -60,6 +68,12 @@ pub fn generate_component(item: ItemFn) -> syn::Result<TokenStream> {
 
         impl #name {
             #builder_methods
+        }
+
+        impl ::gpui::ParentElement for #name {
+            fn extend(&mut self, elements: impl ::std::iter::IntoIterator<Item = ::gpui::AnyElement>) {
+                self.children.extend(elements);
+            }
         }
 
         impl ::gpui::IntoElement for #name {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,6 +513,7 @@ use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
 mod codegen;
+mod component;
 mod diagnostics;
 mod parser;
 
@@ -650,4 +651,17 @@ pub fn rsx_expand(input: TokenStream) -> TokenStream {
     let preview = generate_body_expansion_preview(&body, ClassMode::Permissive);
     let code = quote::quote! { #preview };
     TokenStream::from(code)
+}
+
+/// Generates a functional component builder for GPUI.
+///
+/// This macro transforms a stateless function into a fully-fledged GPUI element struct,
+/// allowing it to be used like `<Component prop="value" />` in `rsx!`.
+#[proc_macro_attribute]
+pub fn component(_args: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as syn::ItemFn);
+    match component::generate_component(input) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,10 +8,10 @@ use proc_macro2::{Delimiter, Span, TokenStream, TokenTree};
 use quote::ToTokens;
 use std::fmt;
 use syn::{
-    Expr, ExprLit, Ident, Lit, Pat, Result, Token,
+    ext::IdentExt,
     parse::{Parse, ParseStream, Parser},
     spanned::Spanned,
-    token,
+    token, Expr, ExprLit, Ident, Lit, Pat, Result, Token,
 };
 
 /// RSX 宏体
@@ -157,7 +157,7 @@ impl Parse for RsxElement {
         // 解析属性（预分配容量，典型元素有 3-8 个属性）
         let mut attributes = Vec::with_capacity(4);
         while !input.peek(Token![>]) && !input.peek(Token![/]) {
-            let attr_name: Ident = input.parse()?;
+            let attr_name = syn::Ident::parse_any(input)?;
 
             if input.peek(Token![=]) {
                 // 值属性: name={value}


### PR DESCRIPTION
This pull request introduces functional component support to the codebase, allowing stateless Rust functions to be used as components in RSX syntax. It also adds a demo for functional components and improves attribute handling and parsing logic. The most important changes are grouped below.

### Functional component system

* Added a `#[component]` procedural macro (`src/lib.rs`, `src/component.rs`) that transforms stateless functions into GPUI element structs, enabling usage like `<Component prop="value" />` in RSX. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R655-R667) [[2]](diffhunk://#diff-c34cb87be68214956fa84ca439e1a52f71ace0cae10c5f8e5e15d072aace9ed8R1-R93)
* Implemented a demo functional component (`FunctionalButton`) and sample usage in `demo/src/button.rs` and `demo/src/bin/functional_component.rs`. [[1]](diffhunk://#diff-db0faf6f8de53f910b06a9b667446f90989f9cf594dfd7858000af071e71b962R1-R14) [[2]](diffhunk://#diff-8ae5bf45d0f8f3f55f5331398660d27b7d1c49e51503e1e802abbbf0756d0f69R1-R39) [[3]](diffhunk://#diff-8441d8ab6467defbccf7b0fddbb3c9bfb9e347c544ec03b370a9eccfb79d3983R1)

### Attribute and element codegen improvements

* Special-cased the `ref` attribute to generate `.track_focus(...)` method calls in codegen.
* Improved support for the `mode` attribute on the `Activity` tag, mapping its value to visibility methods.
* Prevented unnecessary `id` generation for component tags by distinguishing them from HTML tags.
* Mapped the `Activity` tag to a `div` in RSX codegen for consistency.
* Added detection of component tags by checking if the tag starts with an uppercase letter.

### Parsing improvements

* Allowed attribute names in RSX to be any identifier (not just Rust identifiers), improving compatibility with JSX-like syntax. [[1]](diffhunk://#diff-4a04259da480a6b794a2e947e4cc03eff4d1aa9330836f5b91cac68c5398193fL11-R14) [[2]](diffhunk://#diff-4a04259da480a6b794a2e947e4cc03eff4d1aa9330836f5b91cac68c5398193fL160-R160)

### Testing and demonstration

* Added a simple test binary for RSX expansion with a `ref` attribute in `demo/src/bin/test_component.rs`.

These changes collectively enable a more ergonomic and JSX-like experience for writing UI components in Rust using RSX syntax.